### PR TITLE
Implemented the password reset form

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,3 @@
-<!-- no error handling -->
-<!-- css variables -->
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -43,28 +40,47 @@
       .password-reset > form {
         border: 1px solid #eaeaea;
         background-color: #f7f7f7;
-        padding: 2rem;
+        padding: 2.5rem 1rem;
       }
 
-      .password-reset > form > .error {
+      .password-reset > form > .message,
+      .password-reset > form > .submessage {
         text-align: center;
         max-width: 33rem;
         margin: 0 auto;
-        margin-top: 1rem;
+      }
+
+      .password-reset > form > .message {
         margin-bottom: 2rem;
-        color: #f82c30;
         font-weight: bold;
         font-size: 1rem;
         display: none;
       }
 
-      .password-reset > form.error > .error {
+      .password-reset > form > .submessage {
+        margin-bottom: 3.5rem;
+        font-size: 0.95rem;
+        display: none;
+      }
+
+      .password-reset > form.error > .message {
+        display: block;
+        color: #f82c30;
+      }
+
+      .password-reset > form.success > .message {
+        display: block;
+        color: #005194;
+      }
+
+      .password-reset > form.success > .submessage {
         display: block;
       }
 
       .password-reset > form > label,
       .password-reset > form > .submit,
-      .password-reset > form > .help {
+      .password-reset > form > .help,
+      .password-reset > form > .help-message {
         max-width: 30rem;
         margin: 0 auto;
         display: block;
@@ -76,7 +92,7 @@
 
       .password-reset > form > label > input {
         display: block;
-        border: 1px solid #797979;
+        border: 1px solid #2c2c2c;
         border-radius: 3px;
         margin-top: 0.4rem;
         padding: 0.7rem 1rem;
@@ -85,18 +101,34 @@
       }
 
       .password-reset > form > label > input::placeholder {
-        color: #222222;
         font-size: 0.9rem;
+        color: #2c2c2c;
+      }
+
+      .password-reset > form > label > input:focus {
+        background-color: #e8f1f8;
+        border-color: #787979;
       }
 
       .password-reset > form > label > .message {
-        font-size: 0.8rem;
-        font-style: italic;
-        color: #f92529;
         display: none;
       }
 
-      .password-reset > form.error > label > .message {
+      .password-reset > form > label.error > input {
+        border-color: #f82c30;
+        background-color: #feeff0;
+      }
+
+      .password-reset > form > label.error > input::placeholder {
+        color: black;
+      }
+
+      .password-reset > form > label.error > .message {
+        font-size: 0.8rem;
+        font-style: italic;
+        margin-top: 0.2rem;
+        margin-bottom: -1rem;
+        color: #f92529;
         display: block;
       }
 
@@ -114,7 +146,13 @@
         font-weight: bold;
         font-size: 1.1rem;
         padding: 1rem 4rem;
+        cursor: pointer;
         border: 0;
+      }
+
+      .password-reset > form > .submit > button:hover,
+      .password-reset > form > .submit > button:focus {
+        background-color: #003561;
       }
 
       .password-reset > form > .submit > .back {
@@ -146,6 +184,37 @@
         position: relative;
         bottom: 0.1rem;
       }
+
+      .password-reset > form > .help-message {
+        border: 1px solid #c0c0c0;
+        background-color: white;
+        padding: 1.2rem;
+        margin-top: 1rem;
+        box-sizing: border-box;
+        font-size: 0.9rem;
+        display: none;
+      }
+
+      .password-reset > form > .help-message.shown {
+        display: block;
+      }
+
+      @media (max-width: 32rem) {
+        .password-reset > form,
+        .password-reset > form > label > input {
+          text-align: center;
+        }
+
+        .password-reset > form > .submit {
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
+        .password-reset > form > .submit > button {
+          width: 100%;
+          margin-bottom: 0.5rem;
+        }
+      }
     </style>
   </head>
   <body>
@@ -154,7 +223,8 @@
       <p>Please enter your email address below to receive a password reset link.</p>
 
       <form>
-        <p class="error">Sorry, there is no account attached to that email address</p>
+        <p class="message"></p>
+        <p class="submessage"></p>
 
         <label>
           Email Address
@@ -163,7 +233,7 @@
         </label>
 
         <div class="submit">
-          <button>Reset Password</button>
+          <button type="submit">Reset Password</button>
           <a class="back" href="#">Go Back</a>
         </div>
 
@@ -173,12 +243,18 @@
         </div>
 
         <div class="help-message">
-
+          We have some customers who...
         </div>
       </form>
     </div>
 
     <script>
+      /* from: https://stackoverflow.com/a/46181 */
+      function is_valid_email(email) {
+        const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        return re.test(String(email).toLowerCase());
+      }
+
       async function query_email(email) {
         let response = await fetch(
           "http://localhost:3005/customer/account/resetPassword", {
@@ -193,7 +269,56 @@
         return await response.json();
       }
 
-      query_email("lol@bob.com");
+      function submit_form(form, email_label, email) {
+        query_email(email).then(response => {
+          let message = form.querySelector(".message");
+          let submessage = form.querySelector(".submessage");
+
+          if (response.errors.length) {
+            form.classList.add("error");
+            form.classList.remove("success");
+            email_label.classList.add("error");
+            message.innerText = response.errors[0].detail;
+          } else {
+            form.classList.add("success");
+            form.classList.remove("error");
+            message.innerText = "Success, we have emailed your password reset link.";
+            submessage.innerText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur malesuada nibh sed elit dignissim vehicula. Donec dictum lacus bibendum velit molestie, id lobortis nulla suscipit.";
+          }
+        });
+      }
+
+      function listen_for_form_submits() {
+        let form = document.querySelector(".password-reset > form");
+
+        form.addEventListener("submit", function(event) {
+          let email_label = form.querySelector("label");
+          let email_input = email_label.querySelector("input[name=email]");
+          let email = email_input.value;
+
+          if (is_valid_email(email)) {
+            email_label.classList.remove("error");
+            submit_form(form, email_label, email);
+          } else {
+            email_label.classList.add("error");
+          }
+
+          event.preventDefault();
+        });
+      }
+
+      function listen_for_help_clicks() {
+        let link = document.querySelector(".password-reset > form > .help");
+
+        link.addEventListener("click", function(event) {
+          let box = document.querySelector(".password-reset > form > .help-message");
+          box.classList.toggle("shown");
+          event.preventDefault();
+        });
+      }
+
+      listen_for_form_submits();
+      listen_for_help_clicks();
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,6 @@
+<!-- no error handling -->
+<!-- css variables -->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -6,8 +9,191 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="./styles/app.pcss" />
     <script async src="./scripts/app.ts"></script>
+
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 64rem;
+        margin: 0 auto;
+        padding: 1rem;
+        color: #2c2c2c;
+      }
+
+      .password-reset {
+        padding: 2rem 0;
+      }
+
+      .password-reset > h2,
+      .password-reset > p {
+        text-align: center;
+        margin: 0;
+      }
+
+      .password-reset > h2 {
+        text-align: center;
+        font-size: 1.5rem;
+        margin-bottom: 0.6rem;
+      }
+
+      .password-reset > p {
+        font-size: 0.9rem;
+        margin-bottom: 1.6rem;
+      }
+
+      .password-reset > form {
+        border: 1px solid #eaeaea;
+        background-color: #f7f7f7;
+        padding: 2rem;
+      }
+
+      .password-reset > form > .error {
+        text-align: center;
+        max-width: 33rem;
+        margin: 0 auto;
+        margin-top: 1rem;
+        margin-bottom: 2rem;
+        color: #f82c30;
+        font-weight: bold;
+        font-size: 1rem;
+        display: none;
+      }
+
+      .password-reset > form.error > .error {
+        display: block;
+      }
+
+      .password-reset > form > label,
+      .password-reset > form > .submit,
+      .password-reset > form > .help {
+        max-width: 30rem;
+        margin: 0 auto;
+        display: block;
+      }
+
+      .password-reset > form > label {
+        margin-bottom: 1.6rem;
+      }
+
+      .password-reset > form > label > input {
+        display: block;
+        border: 1px solid #797979;
+        border-radius: 3px;
+        margin-top: 0.4rem;
+        padding: 0.7rem 1rem;
+        box-sizing: border-box;
+        width: 100%;
+      }
+
+      .password-reset > form > label > input::placeholder {
+        color: #222222;
+        font-size: 0.9rem;
+      }
+
+      .password-reset > form > label > .message {
+        font-size: 0.8rem;
+        font-style: italic;
+        color: #f92529;
+        display: none;
+      }
+
+      .password-reset > form.error > label > .message {
+        display: block;
+      }
+
+      .password-reset > form > .submit {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 2rem;
+      }
+
+      .password-reset > form > .submit > button {
+        background-color: #005194;
+        color: white;
+        border-radius: 3px;
+        font-weight: bold;
+        font-size: 1.1rem;
+        padding: 1rem 4rem;
+        border: 0;
+      }
+
+      .password-reset > form > .submit > .back {
+        color: #005194;
+        text-decoration: none;
+      }
+
+      .password-reset > form > .submit > .back:hover,
+      .password-reset > form > .submit > .back:focus {
+        color: #2c2c2c;
+      }
+
+      .password-reset > form > .help {
+        color: #005194;
+        text-decoration: none;
+        cursor: pointer;
+        font-size: 0.95rem;
+      }
+
+      .password-reset > form > .help:hover,
+      .password-reset > form > .help:focus {
+        color: #2c2c2c;
+      }
+
+      .password-reset > form > .help > .arrow {
+        transform: rotate(180deg);
+        display: inline-block;
+        font-size: 1.2rem;
+        position: relative;
+        bottom: 0.1rem;
+      }
+    </style>
   </head>
   <body>
-    <div>Replace me with the exercise design</div>
+    <div class="password-reset">
+      <h2>Forgot Your Password?</h2>
+      <p>Please enter your email address below to receive a password reset link.</p>
+
+      <form>
+        <p class="error">Sorry, there is no account attached to that email address</p>
+
+        <label>
+          Email Address
+          <input type="text" name="email" placeholder="Your email address">
+          <span class="message">Please enter a valid email address</span>
+        </label>
+
+        <div class="submit">
+          <button>Reset Password</button>
+          <a class="back" href="#">Go Back</a>
+        </div>
+
+        <div class="help">
+          Are you having trouble receiving your password reset?
+          <span class="arrow">^</span>
+        </div>
+
+        <div class="help-message">
+
+        </div>
+      </form>
+    </div>
+
+    <script>
+      async function query_email(email) {
+        let response = await fetch(
+          "http://localhost:3005/customer/account/resetPassword", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({email: email})
+          }
+        );
+
+        return await response.json();
+      }
+
+      query_email("lol@bob.com");
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Hello! This feature has now been implemented.

I started this ticket by first adding in the HTML and CSS, gradually getting it to have all the necessary states given the designs, i.e. error states, success states, and so on. Once that was all in place, I added the event listeners in JavaScript and got that all working. Once that was done, I tested it for mobiles and submitted.

At one hour in, I wasn't finished, so I committed what I had at that stage and then carried on. This way you can see both what I had at the one hour mark, and what I had when it was basically done.

With more time, I would have:

- Filled in the help message box (15 minutes)
- More error handling, namely if the fetch request fails (10 minutes)
- Made the JavaScript account for the possibility that more than one of these components could be on a single page; currently it assumes there is only one instance (10 minutes)
- I would have made the arrow in the help message spin when clicked (5 minutes)
- I would have also added some transitions to help things feel a bit smoother and less jolting (20 minutes)

I should also note that: 

- The 'Go Back' button would still need linking up
- I put everything in a single file, as I wasn't using .ts or .pcss
- I would have used CSS variables, but in this case the font name and colours and so on have been hard-coded in
- GitHub doesn't seem to want to let me make this repo private, as apparently that can't be done on forks, unless I'm missing the right option

Thank you for your time!